### PR TITLE
New metadata method compatibility with Chef versions <12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'Sean OMeara <someara@chef.io>'
 license 'Apache 2.0'
 description 'Installs/Configures yum-repoforge'
 version '0.5.1'
-source_url 'https://github.com/chef-cookbooks/yum-repoforge'
-issues_url 'https://github.com/chef-cookbooks/yum-repoforge/issues'
+source_url 'https://github.com/chef-cookbooks/yum-repoforge' if respond_to?(:source_url)
+issues_url 'https://github.com/chef-cookbooks/yum-repoforge/issues' if respond_to?(:issues_url)
 
 depends 'yum', '~> 3.0'
 depends 'yum-epel'


### PR DESCRIPTION
Chef versions <12 will fail on the new Supermarket metadata attributes.

See https://github.com/chef/chef/blob/9760d40e2f924e8fdd5b42760c4fb775572fb777/RELEASE_NOTES.md#new-cookbook-metadata-attributes-for-supermarket